### PR TITLE
Refactor components to be functional and use hooks

### DIFF
--- a/src/components/albums.js
+++ b/src/components/albums.js
@@ -1,50 +1,48 @@
-import React, { Component } from "react";
-import { Button, Card, Container, Row, Col } from 'react-bootstrap';
-import '../App.css';
-import PetSoundsCover from '../PetSoundsCover.jpg';
-import RevolverCover from '../RevolverCover.jpg';
+import React, { useState } from "react";
+import { Button, Card, Container, Row, Col } from "react-bootstrap";
+import "../App.css";
+import PetSoundsCover from "../PetSoundsCover.jpg";
+import RevolverCover from "../RevolverCover.jpg";
 
-class Albums extends Component {
-  state = {
+const beatlesAlbum = {
     image: RevolverCover,
     releaseYear: 1966,
-    name: "The Beatles",
-    album: "Revolver",
-    used: false
-  };
+    artist: "The Beatles",
+    name: "Revolver",
+    used: false,
+};
 
-  switchAlbum = () => {
-    this.setState({
-      image: PetSoundsCover,
-      releaseYear: 1966,
-      name: "The Beach Boys",
-      album: "Pet Sounds",
-      used: true
-    });
-  };
+const beachBoysAlbum = {
+    image: PetSoundsCover,
+    releaseYear: 1966,
+    artist: "The Beach Boys",
+    name: "Pet Sounds",
+    used: true,
+};
 
-  render() {
+const Albums = () => {
+    const [album, setAlbum] = useState(beatlesAlbum);
     return (
-      <Container>
-        <Row>
-          <Col>
-          <h2>Challenge 1: Switch Albums</h2>
-          <Card className="Album" style={{ width: '18rem', display: 'inline-flex', margin: '50px' }}>
-            <Card.Img variant="top" src={this.state.image} />
-              <Card.Body>
-                  <Card.Text>{this.state.album}</Card.Text>
-                  <Card.Text>{this.state.name}</Card.Text>
-                  <Card.Text>{this.state.releaseYear}</Card.Text>
-                  <Card.Text>{this.state.used ? "Used Album" : "New Album"}</Card.Text>
-                  <Button variant="outline-success" onClick={this.switchAlbum}>Switch Album</Button>
-              </Card.Body>
-          </Card>
-          </Col>
-        </Row>
-      </Container>
-       
+        <Container>
+            <Row>
+                <Col>
+                    <h2>Challenge 1: Switch Albums</h2>
+                    <Card className="Album" style={{ width: "18rem", display: "inline-flex", margin: "50px" }}>
+                        <Card.Img variant="top" src={album.image} />
+                        <Card.Body>
+                            <Card.Text>{album.name}</Card.Text>
+                            <Card.Text>{album.artist}</Card.Text>
+                            <Card.Text>{album.releaseYear}</Card.Text>
+                            <Card.Text>{album.used ? "Used Album" : "New Album"}</Card.Text>
+                            <Button variant="outline-success" onClick={() => setAlbum(beachBoysAlbum)}>
+                                Switch Album
+                            </Button>
+                        </Card.Body>
+                    </Card>
+                </Col>
+            </Row>
+        </Container>
     );
-  }
-}
+};
 
 export default Albums;

--- a/src/components/counter.js
+++ b/src/components/counter.js
@@ -1,27 +1,36 @@
-import React, { Component } from "react";
-import Button from 'react-bootstrap/Button';
+import React, { useReducer } from "react";
+import Button from "react-bootstrap/Button";
 
-class Counter extends Component {
-  state = {
-    count: 0
-  };
-  add = () => {
-    this.setState({ count: this.state.count + 1 });
-  };
-  subtract = () => {
-    this.setState({ count: this.state.count - 1 });
-  };
+const initialCount = 0;
+const countReducer = (state, action) => {
+    switch (action.type) {
+        case "add": {
+            return state + 1;
+        }
+        case "subtract": {
+            return state - 1;
+        }
+        default:
+            throw new Error(`Invalid action dispatched to countReducer: ${action.type}`);
+    }
+};
 
-  render() {
+const Counter = () => {
+    const [count, countDispatch] = useReducer(countReducer, initialCount);
+    const add = () => countDispatch({ type: "add" });
+    const subtract = () => countDispatch({ type: "subtract" });
     return (
-      <div style={{ marginBottom: "50px" }}>
-        <h2>Challenge 2: Counter</h2>
-        <p>Count is: {this.state.count}</p>
-        <Button variant="outline-success" onClick={this.add}>+</Button>{' '}
-        <Button variant="outline-danger" onClick={this.subtract}>-</Button>{' '}
-      </div>
+        <div style={{ marginBottom: "50px" }}>
+            <h2>Challenge 2: Counter</h2>
+            <p>Count is: {count}</p>
+            <Button variant="outline-success" onClick={add}>
+                +
+            </Button>
+            <Button variant="outline-danger" onClick={subtract}>
+                -
+            </Button>
+        </div>
     );
-  }
-}
+};
 
 export default Counter;

--- a/src/components/surprise.js
+++ b/src/components/surprise.js
@@ -1,18 +1,13 @@
-import React, { Component } from "react";
-import cuteSloth from '../cuteSloth.jpg';
+import React, { useEffect } from "react";
+import cuteSloth from "../cuteSloth.jpg";
 
-class Surprise extends Component {
-  componentWillUnmount() {
-    alert("Now I must go");
-  }
-
-  render() {
+const Surprise = () => {
+    useEffect(() => () => alert("Now I must go"), []);
     return (
-      <div style={{ margin: "20px"}}>
-        <img style={{height: "200px", width: "300px"}} src={cuteSloth} alt="Sloth" />
-      </div>
+        <div style={{ margin: "20px" }}>
+            <img style={{ height: "200px", width: "300px" }} src={cuteSloth} alt="Sloth" />
+        </div>
     );
-  }
-}
+};
 
 export default Surprise;

--- a/src/components/toggle.js
+++ b/src/components/toggle.js
@@ -1,24 +1,19 @@
-import React, { Component } from "react";
+import React, { useState } from "react";
 import Surprise from "./surprise";
-import Button from 'react-bootstrap/Button';
+import Button from "react-bootstrap/Button";
 
-class Toggle extends Component {
-  state = {
-    showSurprise: true
-  };
-  revealSurprise = () => {
-    this.setState({ showSurprise: !this.state.showSurprise });
-  };
-
-  render() {
+const Toggle = () => {
+    const [showSurprise, setShowSurprise] = useState(true);
+    const toggleSurprise = () => setShowSurprise(!showSurprise);
     return (
-      <div style={{ margin: "20px" }}>
-        <h2>Challenge 3: Toggle</h2>
-        <Button variant="outline-success" onClick={this.revealSurprise}>{!this.state.showSurprise ? "Show" : "Remove" } the cute sloth</Button>
-        {this.state.showSurprise ? <Surprise /> : ""}
-      </div>
+        <div style={{ margin: "20px" }}>
+            <h2>Challenge 3: Toggle</h2>
+            <Button variant="outline-success" onClick={toggleSurprise}>
+                {showSurprise ? "Remove" : "Show"} the cute sloth
+            </Button>
+            {showSurprise && <Surprise />}
+        </div>
     );
-  }
-}
+};
 
 export default Toggle;


### PR DESCRIPTION
This refactor maintains the same behavior of these components, while
changing from class components into functional components. State is
managed within these components using hooks.

The album is left as a one-way change from Beatles to Beach Boys, as
the original component did. Since the behavior was simple, I used a
basic useState hook for this component.

The counter had a slightly more complex behavior, with two different
side effects which could manipulate the state (`add` and `subtract`),
so I used the useReducer hook for this component to make the behavior
explicit, while keeping it organized.

The surprise component had a side effect which needed to be fired at
a specific point in the component lifecycle, so I pulled in the useEffect
hook. It only needs to execute once, upon unmount, so it has no dependencies
to list in the dependency array. Since there is nothing for it to do
until it is removed from the screen, the effect is merely a single
return statement containing a function to execute the alert.

For the toggle component, it was again a simple boolean state to keep
track of with a single behavior (flipping the boolean), so I leveraged
the useState hook again. I also simplified the logic a bit in the
component where there were double negatives and unnecessary empty strings.